### PR TITLE
Fix regex to match nginx syntax includes

### DIFF
--- a/tasks/lib/ssi.js
+++ b/tasks/lib/ssi.js
@@ -21,8 +21,8 @@ module.exports = function (grunt) {
     var defaults = {
         cacheDir: '.tmp/html',
         fileSep: path.sep,
-        ssiRegex: /<!--\s*\#include\s+(file|virtual)=["']([^"'<>|\b]+)['"]\s*-->/gi,
-        includeRegex: /<!--\s*\#include\s+(file|virtual)=["']([^"'<>|\b]+)['"]\s*-->/,
+        ssiRegex: /<!--\s*\#\s*include\s+(file|virtual)=["']([^"'<>|\b]+)['"]\s*-->/gi,
+        includeRegex: /<!--\s*\#\s*include\s+(file|virtual)=["']([^"'<>|\b]+)['"]\s*-->/,
         cache: true,
         ext: '.html',
         baseDir: process.cwd(),


### PR DESCRIPTION
As per nginx SSI documentation (http://nginx.org/en/docs/http/ngx_http_ssi_module.html) whitespace between # and command is allowed.