### PR TITLE
Added target around "files" in README examples as seems to be require…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ Typical Settings as such read in `.html` files in the `/html` directory, and out
 grunt.initConfig({
   ssi: {
     options: {},
-    files: [{
+    target: {
+      files: [{
           expand: true,
           cwd: 'html',
           src: ['**/*.html'],
           dest: '.tmp/html'
         }],
+    }
   },
 });
 ```
@@ -102,12 +104,14 @@ grunt.initConfig({
       ext: '.shtml',
       baseDir: 'path/to/views',
     },
-    files: [{
+    target: {
+      files: [{
           expand: true,
           cwd: 'html',
           src: ['**/*.html'],
-          dest: '.tmp/html',
-        }],
+          dest: '.tmp/html'
+        }]
+    }
   },
 });
 ```


### PR DESCRIPTION
…d by grunt

(The example wouldn't run for me without a target specified.  Maybe it worked with an earlier version of grunt.  I am using 0.4.5.)